### PR TITLE
feat: display added rulesets + easily add sample ruleset data and reset it

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* poultetr lysng madrym
+* troypoulter lysng madrym

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* poultetr lysng madrym

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* troypoulter lysng madrym
+* @troypoulter @lysng @madrym

--- a/app/components/rulesets.tsx
+++ b/app/components/rulesets.tsx
@@ -152,7 +152,7 @@ export default function Rulesets() {
           <Form {...form}>
             <form
               onSubmit={form.handleSubmit(onSubmit)}
-              className="grid grid-flow-row auto-rows-max gap-4"
+              className="grid gap-4 sm:grid-cols-2 md:grid-cols-5"
             >
               <FormField
                 control={form.control}

--- a/app/components/rulesets.tsx
+++ b/app/components/rulesets.tsx
@@ -87,6 +87,7 @@ export type Ruleset = z.infer<typeof rulesetSchema>
 
 export default function Rulesets() {
   const [rulesets, setRulesets] = useState<Ruleset[]>([])
+  const [isSampleDataAdded, setIsSampleDataAdded] = useState(false)
 
   // https://github.com/shadcn/ui/issues/549
   const form = useForm<z.infer<typeof rulesetSchema>>({
@@ -105,6 +106,67 @@ export default function Rulesets() {
     setRulesets((rulesets) => [...rulesets, newRuleset])
   }
 
+  function addSampleRuleset() {
+    setIsSampleDataAdded(true)
+    setRulesets((rulesets) => [
+      ...rulesets,
+      {
+        name: "Normal Hours",
+        dayOfWeek: "Monday",
+        startTime: "9:00 AM",
+        endTime: "5:00 PM",
+        multipler: 1.0,
+      },
+      {
+        name: "Normal Hours",
+        dayOfWeek: "Tuesday",
+        startTime: "9:00 AM",
+        endTime: "5:00 PM",
+        multipler: 1.0,
+      },
+      {
+        name: "Normal Hours",
+        dayOfWeek: "Wednesday",
+        startTime: "9:00 AM",
+        endTime: "5:00 PM",
+        multipler: 1.0,
+      },
+      {
+        name: "Normal Hours",
+        dayOfWeek: "Thursday",
+        startTime: "9:00 AM",
+        endTime: "5:00 PM",
+        multipler: 1.0,
+      },
+      {
+        name: "Normal Hours",
+        dayOfWeek: "Friday",
+        startTime: "9:00 AM",
+        endTime: "5:00 PM",
+        multipler: 1.0,
+      },
+      {
+        name: "Weekend Hours",
+        dayOfWeek: "Saturday",
+        startTime: "9:00 AM",
+        endTime: "5:00 PM",
+        multipler: 2.0,
+      },
+      {
+        name: "Weekend Hours",
+        dayOfWeek: "Sunday",
+        startTime: "9:00 AM",
+        endTime: "5:00 PM",
+        multipler: 2.0,
+      },
+    ])
+  }
+
+  function resetRulesets() {
+    setIsSampleDataAdded(false)
+    setRulesets([])
+  }
+
   useEffect(() => {
     if (form.formState.isSubmitSuccessful) {
       console.log("hello!")
@@ -115,7 +177,7 @@ export default function Rulesets() {
   // TODO: Make the form items appear side-by-side.
   return (
     <>
-      <Table className="mb-8">
+      <Table className="mb-4">
         <TableHeader>
           <TableRow>
             <TableHead>Ruleset Name</TableHead>
@@ -127,7 +189,9 @@ export default function Rulesets() {
         </TableHeader>
         <TableBody>
           {rulesets.map((ruleset) => (
-            <TableRow>
+            <TableRow
+              key={`${ruleset.name}-${ruleset.dayOfWeek}-${ruleset.multipler}`}
+            >
               <TableCell>{ruleset.name}</TableCell>
               <TableCell>{ruleset.dayOfWeek}</TableCell>
               <TableCell>{ruleset.startTime}</TableCell>
@@ -144,6 +208,21 @@ export default function Rulesets() {
           )}
         </TableBody>
       </Table>
+      <Button
+        onClick={addSampleRuleset}
+        variant="secondary"
+        className="col-span-full mt-2 w-full"
+        disabled={isSampleDataAdded}
+      >
+        Add Sample Data
+      </Button>
+      <Button
+        onClick={resetRulesets}
+        variant="outline"
+        className="col-span-full mb-8 mt-2 w-full"
+      >
+        Remove Rulesets
+      </Button>
       <Card>
         <CardHeader>
           <CardTitle>Add a new ruleset</CardTitle>

--- a/app/components/rulesets.tsx
+++ b/app/components/rulesets.tsx
@@ -25,6 +25,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 
 // Import this dynamically to avoid hydration issues.
 // https://github.com/react-hook-form/devtools/issues/187
@@ -106,8 +115,35 @@ export default function Rulesets() {
   // TODO: Make the form items appear side-by-side.
   return (
     <>
-      <pre>{JSON.stringify(rulesets, null, 2)}</pre>
-      <DevT control={form.control} />
+      <Table className="mb-8">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Ruleset Name</TableHead>
+            <TableHead>Applicable Days</TableHead>
+            <TableHead>Start Time</TableHead>
+            <TableHead>End Time</TableHead>
+            <TableHead>Multipler</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rulesets.map((ruleset) => (
+            <TableRow>
+              <TableCell>{ruleset.name}</TableCell>
+              <TableCell>{ruleset.dayOfWeek}</TableCell>
+              <TableCell>{ruleset.startTime}</TableCell>
+              <TableCell>{ruleset.endTime}</TableCell>
+              <TableCell>{ruleset.multipler}</TableCell>
+            </TableRow>
+          ))}
+          {rulesets.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={5} className="text-center">
+                No rulesets added yet, you can add them below.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
       <Card>
         <CardHeader>
           <CardTitle>Add a new ruleset</CardTitle>
@@ -343,6 +379,7 @@ export default function Rulesets() {
                 Add Ruleset
               </Button>
             </form>
+            <DevT control={form.control} />
           </Form>
         </CardContent>
       </Card>

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn("bg-primary font-medium text-primary-foreground", className)}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -84,7 +84,10 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn(
+      "px-4 py-2 align-middle [&:has([role=checkbox])]:pr-0",
+      className
+    )}
     {...props}
   />
 ))


### PR DESCRIPTION
Relates to #2.

- Add simple table view of added rulesets.
- Add sample data and reset data button for rulesets.
- Made ruleset form responsive.

![image](https://github.com/troypoulter/toil-calculator/assets/19419349/76bf2d95-046f-4a51-9a08-5998f4ddc28a)

![image](https://github.com/troypoulter/toil-calculator/assets/19419349/41ee6eda-6154-44cb-8cb4-749877862b85)
